### PR TITLE
Clean up unused imports flagged by lint

### DIFF
--- a/accordion_widget.py
+++ b/accordion_widget.py
@@ -5,10 +5,10 @@ from PyQt6.QtWidgets import (
     QFrame, QPushButton, QVBoxLayout, QHBoxLayout, QLabel, 
     QWidget, QSizePolicy
 )
-from PyQt6.QtGui import QPixmap, QColor # QColor for Qt.GlobalColor.transparent
+from PyQt6.QtGui import QPixmap
 from PyQt6.QtCore import (
-    Qt, QPropertyAnimation, QEasingCurve, pyqtSignal, QThread, 
-    QObject, pyqtSlot # QObject is parent of PingWorker. QThread, pyqtSlot for ping mechanism.
+    Qt, QPropertyAnimation, QEasingCurve, pyqtSignal, QThread,
+    pyqtSlot # QThread, pyqtSlot for ping mechanism.
 )
 from matplotlib.backends.backend_qt5agg import FigureCanvasQTAgg as FigureCanvas
 import matplotlib.pyplot as plt

--- a/main_window.py
+++ b/main_window.py
@@ -1,4 +1,3 @@
-import sys 
 import os
 import logging
 import requests
@@ -6,11 +5,11 @@ import json
 import copy
 
 from PyQt6.QtWidgets import (
-    QApplication, QWidget, QVBoxLayout, QHBoxLayout, QLabel, QPushButton, 
-    QMainWindow, QSystemTrayIcon, QMenu, QMessageBox, QStyle, QStyleOptionSizeGrip
+    QApplication, QWidget, QVBoxLayout, QPushButton,
+    QMainWindow, QSystemTrayIcon, QMenu, QMessageBox, QStyle
 )
-from PyQt6.QtGui import QIcon, QPixmap, QAction, QPainter, QColor, QCursor
-from PyQt6.QtCore import Qt, QTimer, QPoint, pyqtSignal, QSize
+from PyQt6.QtGui import QIcon, QPixmap, QAction, QPainter, QColor
+from PyQt6.QtCore import Qt, QTimer
 
 # Imports for the previously refactored classes
 from accordion_widget import AccordionWidget 

--- a/resize_grip.py
+++ b/resize_grip.py
@@ -1,7 +1,6 @@
-import logging # It's good practice to have logging available, even if not used initially
 from PyQt6.QtWidgets import QWidget, QStyleOptionSizeGrip, QStyle
 from PyQt6.QtGui import QPainter
-from PyQt6.QtCore import Qt, QPoint
+from PyQt6.QtCore import Qt
 
 class ResizeGrip(QWidget):
     """Грип для изменения размера окна."""


### PR DESCRIPTION
## Summary
- remove unused PyQt imports that were triggering ruff warnings
- drop unused logging import from the resize grip helper to keep the module minimal

## Testing
- pytest
- ruff check .
- python -m compileall .

------
https://chatgpt.com/codex/tasks/task_e_68ea080c14bc83278bbc5f41c8da8ab0